### PR TITLE
Update package publishing to npm.org

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -26,8 +26,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 16
-          registry-url: https://npm.pkg.github.com/
+          registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
-@barnardoswebteam:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
+registry=https://registry.npmjs.org/

--- a/package.json
+++ b/package.json
@@ -19,8 +19,5 @@
   "bugs": {
     "url": "https://github.com/barnardos/tiktok-regex/issues"
   },
-  "homepage": "https://github.com/barnardos/tiktok-regex#readme",
-  "publishConfig": {
-    "@barnardoswebteam:registry": "https://npm.pkg.github.com"
-  }
+  "homepage": "https://github.com/barnardos/tiktok-regex#readme"
 }


### PR DESCRIPTION
Updates the package publishing configuration to target npm.org instead of GitHub Packages.

- Removes the `publishConfig` field from `package.json` to default the publishing registry to npm.org.
- Updates the `registry-url` in the `.github/workflows/release-package.yml` to `https://registry.npmjs.org/` and changes the environment variable for authentication to `NPM_TOKEN`.
- Modifies the `.npmrc` file to specify the npm.org registry URL and removes the GitHub Packages authentication token line.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/barnardos/tiktok-regex?shareId=87f6cb36-0fd9-4a23-a6e1-97ec33d73b6c).